### PR TITLE
Use url.port instead of hardcoding port 80

### DIFF
--- a/http_client.rc
+++ b/http_client.rc
@@ -27,6 +27,7 @@ use std::result;
 use std::result::{Result, Ok, Err};
 use std::cell::Cell;
 use std::str;
+use std::uint;
 use extra::net::ip::{
     get_addr, format_addr,
     IpAddr, IpGetAddrErr, Ipv4, Ipv6
@@ -64,7 +65,7 @@ pub enum RequestError {
     ErrorMisc
 }
 
-/// Request 
+/// Request
 #[deriving(Eq)]
 pub enum RequestEvent {
     Status(StatusCode),
@@ -120,8 +121,12 @@ impl<C: Connection, CF: ConnectionFactory<C>> HttpRequest<C, CF> {
         debug!("http_client: using IP %? for %?", format_addr(&ip_addr), self.url.to_str());
 
         let socket = {
-            debug!("http_client: connecting to %?", ip_addr);
-            let socket = self.connection_factory.connect(copy ip_addr, 80);
+            let port = match self.url.port.clone() {
+                Some(port) => uint::from_str(port).get(),
+                _ => 80
+            };
+            debug!("http_client: connecting to %? on %?", ip_addr, port);
+            let socket = self.connection_factory.connect(copy ip_addr, port);
             if socket.is_ok() {
                 result::unwrap(socket)
             } else {
@@ -284,9 +289,9 @@ impl<C: Connection, CF: ConnectionFactory<C>> HttpRequest<C, CF> {
 }
 
 #[allow(non_implicitly_copyable_typarams)]
-pub fn sequence<C: Connection, CF: ConnectionFactory<C>>(request: &mut HttpRequest<C, CF>) -> 
+pub fn sequence<C: Connection, CF: ConnectionFactory<C>>(request: &mut HttpRequest<C, CF>) ->
     ~[RequestEvent] {
-    
+
     let events = @mut ~[];
     do request.begin |event| {
         events.push(event)


### PR DESCRIPTION
In my Rust project, I want to connect to port 8002. Patch uses `url.port` instead of hardcoded port 80.

Aside: I've got a simple Node.js http-proxy on 8002 to proxy http to https traffic, since we don't have a rust-https-client yet. But, I can't use it without this port tweak.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-http-client/15)

<!-- Reviewable:end -->
