### PR TITLE
Escape query string values. Fixes Issue #16.

### DIFF
--- a/request.rs
+++ b/request.rs
@@ -17,7 +17,10 @@ pub fn build_request(url: Url) -> ~str {
     if url.query.len() > 0 {
         let kvps = do url.query.map |pair| {
             match *pair {
-                (ref key, ref value) => fmt!("%s=%s", *key, *value)
+                (ref key, ref value) => {
+                    let qs_value:~str = (*value).replace(" ", "%20");
+                    fmt!("%s=%s", *key, qs_value)
+                }
             }
         };
         path.push_str("?");


### PR DESCRIPTION
This isn't the most robust fix in the world.
I'm not sure if the fix goes in url::Url or here.

This fixed my use case, so passing it on.
