### PR TITLE
Make test_success use google.com, for reliability

### DIFF
--- a/http_client.rc
+++ b/http_client.rc
@@ -364,7 +364,7 @@ pub fn test_connect_error() {
 #[allow(non_implicitly_copyable_typarams)]
 pub fn test_connect_success() {
     use extra::net::url;
-    let url = url::from_str("http://example.iana.org/").get();
+    let url = url::from_str("http://google.com/").get();
     let mut request = uv_http_request(url);
     let events = sequence(&mut request);
 


### PR DESCRIPTION
In reference to issue https://github.com/mozilla-servo/rust-http-client/issues/22
