### PR TITLE
Direct people to rust-http instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# This library is DEPRECATED
+
+It will not build on current Rust.
+
+See [`rust-http`](https://github.com/chris-morgan/rust-http) instead.


### PR DESCRIPTION
When this lands I'll edit the repo description for `mozilla-servo/rust-http-client` as well.
